### PR TITLE
chore: improve dev workflow with Makefile targets and CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 yatzcli
 /yatz
+coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ mcp/        MCP server for LLM integration (mcp-go, stdio transport)
 p2p/        P2P host-authority online play (length-prefixed JSON over TCP)
 match/      Matchmaking WebSocket client
 lambda/     Serverless matchmaking handler (AWS Lambda + API Gateway + DynamoDB)
+bot/        LLM bot integration (MCP config, system prompt, Claude API interaction)
 ```
 
 ## Key Design Decisions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,24 @@ Yahtzee CLI game in Go. Single binary with local AI play, MCP server for LLM int
 ## Build & Test
 
 ```bash
-go test ./...          # Run all tests
-go build ./cmd/yatz/   # Build binary
-go vet ./...           # Static analysis
+make check             # Quick validation (vet + unit tests + build)
+make test-short        # Unit tests only (skips E2E)
+make test-e2e          # E2E tests only
+make test-all          # All tests with verbose output
+make test-coverage     # Unit tests with coverage report
+make build             # Build binary
+make lint              # Static analysis (go vet)
 ```
+
+## Testing Workflow
+
+1. **開発中の変更確認**: `make check` — vet、ユニットテスト、ビルドを一括実行
+2. **E2Eテスト**: `make test-e2e` — P2PやMCPの統合テスト。ネットワーク系の変更時に実行
+3. **全テスト**: `make test-all` — CIと同等の全テスト実行。PR作成前に推奨
+
+### テスト規約
+- `-short` フラグ: `testing.Short()` でガードされたテストはユニットテスト時にスキップ
+- `TestE2E` プレフィクス: E2Eテストは `TestE2E_` で始める。`-run TestE2E` で選択実行
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet clean
+.PHONY: build test test-short test-e2e test-all test-coverage vet lint check clean
 
 BINARY := yatz
 BUILD_DIR := ./cmd/yatz
@@ -9,8 +9,25 @@ build:
 test:
 	go test ./...
 
+test-short:
+	go test -short ./... -count=1
+
+test-e2e:
+	go test ./... -count=1 -run TestE2E -timeout 120s
+
+test-all:
+	go test ./... -v -count=1 -timeout 120s
+
+test-coverage:
+	go test -short ./... -coverprofile=coverage.out
+	go tool cover -func=coverage.out
+
 vet:
 	go vet ./...
 
+lint: vet
+
+check: vet test-short build
+
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) coverage.out


### PR DESCRIPTION
## Summary
- Makefile に `check`, `test-short`, `test-e2e`, `test-all`, `test-coverage`, `lint` ターゲットを追加
- CLAUDE.md に make ベースの Build & Test セクションと Testing Workflow ガイドを追加
- Project Structure に `bot/` ディレクトリの説明を追加
- `.gitignore` に `coverage.out` を追加

## Test plan
- [x] `make check` (vet + test-short + build) が正常に完了
- [x] `make test-e2e` が E2E テストのみ実行
- [x] `make test-coverage` がカバレッジレポートを出力